### PR TITLE
Fixed format errors in bsp dependency manifest

### DIFF
--- a/rutronik-bsp-dependencies-manifest.xml
+++ b/rutronik-bsp-dependencies-manifest.xml
@@ -5,7 +5,7 @@
       <version>
         <commit>latest-v1.X</commit>
         <dependees>
-		 <dependee>
+	  <dependee>
             <id>cat1cm0p</id>
             <commit>latest-v1.X</commit>
           </dependee>
@@ -34,7 +34,7 @@
       <version>
         <commit>release-v1.0.0</commit>
         <dependees>
-	      <dependee>
+	  <dependee>
             <id>cat1cm0p</id>
             <commit>latest-v1.X</commit>
           </dependee>

--- a/rutronik-bsp-dependencies-manifest.xml
+++ b/rutronik-bsp-dependencies-manifest.xml
@@ -5,7 +5,7 @@
       <version>
         <commit>latest-v1.X</commit>
         <dependees>
-		  <dependee>
+		 <dependee>
             <id>cat1cm0p</id>
             <commit>latest-v1.X</commit>
           </dependee>
@@ -34,7 +34,7 @@
       <version>
         <commit>release-v1.0.0</commit>
         <dependees>
-	      <dependee>
+	     <dependee>
             <id>cat1cm0p</id>
             <commit>latest-v1.X</commit>
           </dependee>

--- a/rutronik-bsp-dependencies-manifest.xml
+++ b/rutronik-bsp-dependencies-manifest.xml
@@ -5,7 +5,7 @@
       <version>
         <commit>latest-v1.X</commit>
         <dependees>
-		<dependee>
+	<dependee>
             <id>cat1cm0p</id>
             <commit>latest-v1.X</commit>
           </dependee>

--- a/rutronik-bsp-dependencies-manifest.xml
+++ b/rutronik-bsp-dependencies-manifest.xml
@@ -5,10 +5,10 @@
       <version>
         <commit>latest-v1.X</commit>
         <dependees>
-	<dependee>
+			<dependee>
             <id>cat1cm0p</id>
             <commit>latest-v1.X</commit>
-          </dependee>
+			</dependee>
           <dependee>
             <id>core-lib</id>
             <commit>latest-v1.X</commit>

--- a/rutronik-bsp-dependencies-manifest.xml
+++ b/rutronik-bsp-dependencies-manifest.xml
@@ -5,7 +5,7 @@
       <version>
         <commit>latest-v1.X</commit>
         <dependees>
-		  <dependee>
+          <dependee>
             <id>cat1cm0p</id>
             <commit>latest-v1.X</commit>
           </dependee>
@@ -34,7 +34,7 @@
       <version>
         <commit>release-v1.0.0</commit>
         <dependees>
-	      <dependee>
+	  <dependee>
             <id>cat1cm0p</id>
             <commit>latest-v1.X</commit>
           </dependee>

--- a/rutronik-bsp-dependencies-manifest.xml
+++ b/rutronik-bsp-dependencies-manifest.xml
@@ -8,7 +8,7 @@
 		 <dependee>
             <id>cat1cm0p</id>
             <commit>latest-v1.X</commit>
-         </dependee>
+          </dependee>
           <dependee>
             <id>core-lib</id>
             <commit>latest-v1.X</commit>

--- a/rutronik-bsp-dependencies-manifest.xml
+++ b/rutronik-bsp-dependencies-manifest.xml
@@ -5,7 +5,7 @@
       <version>
         <commit>latest-v1.X</commit>
         <dependees>
-	      <dependee>
+		 <dependee>
             <id>cat1cm0p</id>
             <commit>latest-v1.X</commit>
           </dependee>

--- a/rutronik-bsp-dependencies-manifest.xml
+++ b/rutronik-bsp-dependencies-manifest.xml
@@ -5,7 +5,7 @@
       <version>
         <commit>latest-v1.X</commit>
         <dependees>
-		 <dependee>
+		  <dependee>
             <id>cat1cm0p</id>
             <commit>latest-v1.X</commit>
           </dependee>
@@ -34,7 +34,7 @@
       <version>
         <commit>release-v1.0.0</commit>
         <dependees>
-	     <dependee>
+	      <dependee>
             <id>cat1cm0p</id>
             <commit>latest-v1.X</commit>
           </dependee>

--- a/rutronik-bsp-dependencies-manifest.xml
+++ b/rutronik-bsp-dependencies-manifest.xml
@@ -5,7 +5,7 @@
       <version>
         <commit>latest-v1.X</commit>
         <dependees>
-	  <dependee>
+		  <dependee>
             <id>cat1cm0p</id>
             <commit>latest-v1.X</commit>
           </dependee>
@@ -34,7 +34,7 @@
       <version>
         <commit>release-v1.0.0</commit>
         <dependees>
-	  <dependee>
+	      <dependee>
             <id>cat1cm0p</id>
             <commit>latest-v1.X</commit>
           </dependee>

--- a/rutronik-bsp-dependencies-manifest.xml
+++ b/rutronik-bsp-dependencies-manifest.xml
@@ -34,7 +34,7 @@
       <version>
         <commit>release-v1.0.0</commit>
         <dependees>
-	  <dependee>
+          <dependee>
             <id>cat1cm0p</id>
             <commit>latest-v1.X</commit>
           </dependee>

--- a/rutronik-bsp-dependencies-manifest.xml
+++ b/rutronik-bsp-dependencies-manifest.xml
@@ -5,10 +5,10 @@
       <version>
         <commit>latest-v1.X</commit>
         <dependees>
-			<dependee>
+		 <dependee>
             <id>cat1cm0p</id>
             <commit>latest-v1.X</commit>
-			</dependee>
+         </dependee>
           <dependee>
             <id>core-lib</id>
             <commit>latest-v1.X</commit>
@@ -34,7 +34,7 @@
       <version>
         <commit>release-v1.0.0</commit>
         <dependees>
-	    <dependee>
+	     <dependee>
             <id>cat1cm0p</id>
             <commit>latest-v1.X</commit>
           </dependee>

--- a/rutronik-bsp-dependencies-manifest.xml
+++ b/rutronik-bsp-dependencies-manifest.xml
@@ -5,7 +5,7 @@
       <version>
         <commit>latest-v1.X</commit>
         <dependees>
-	  <dependee>
+	      <dependee>
             <id>cat1cm0p</id>
             <commit>latest-v1.X</commit>
           </dependee>
@@ -34,7 +34,7 @@
       <version>
         <commit>release-v1.0.0</commit>
         <dependees>
-	  <dependee>
+	      <dependee>
             <id>cat1cm0p</id>
             <commit>latest-v1.X</commit>
           </dependee>

--- a/rutronik-bsp-dependencies-manifest.xml
+++ b/rutronik-bsp-dependencies-manifest.xml
@@ -5,7 +5,7 @@
       <version>
         <commit>latest-v1.X</commit>
         <dependees>
-		 <dependee>
+		<dependee>
             <id>cat1cm0p</id>
             <commit>latest-v1.X</commit>
           </dependee>
@@ -34,7 +34,7 @@
       <version>
         <commit>release-v1.0.0</commit>
         <dependees>
-	     <dependee>
+	    <dependee>
             <id>cat1cm0p</id>
             <commit>latest-v1.X</commit>
           </dependee>


### PR DESCRIPTION
The format error was fixed by correcting the indentation. The Format validation test is passed for bsp dependency manifest.